### PR TITLE
Integrate unused components

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import dynamic from "next/dynamic";
 import StatsSection from "@/components/StatsSection";
+import AdvancedStatsSection from "@/components/AdvancedStatsSection";
 import CTASection from "@/components/CTASection";
 import LatestUpdatesSection from "@/components/LatestUpdatesSection";
 import Footer from "@/components/Footer";
@@ -19,6 +20,7 @@ export default function AboutPage() {
       </section>
 
       <StatsSection />
+      <AdvancedStatsSection />
 
       <section className="container mx-auto text-center space-y-6">
         <h2 className="text-3xl font-bold">Find Donation Centers Near You</h2>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import dynamic from "next/dynamic";
+import Header from "@/components/Header";
+import CTASection from "@/components/CTASection";
+import Footer from "@/components/Footer";
+
+const Map = dynamic(() => import("@/components/map"), { ssr: false });
+const TwitterFeed = dynamic(() => import("@/components/TwitterFeed"), { ssr: false });
+
+export default function ContactPage() {
+  const center = { lat: 6.5244, lng: 3.3792 };
+  const markers: { id: number; position: { lat: number; lng: number } }[] = [];
+
+  return (
+    <div className="space-y-16">
+      <Header />
+      <section className="container mx-auto space-y-6 py-8">
+        <h1 className="text-3xl font-bold">Get in Touch</h1>
+        <p className="text-gray-600">Reach out to us or visit our nearest donation center.</p>
+        <Map center={center} markers={markers} />
+      </section>
+      <section className="container mx-auto py-8">
+        <TwitterFeed />
+      </section>
+      <CTASection />
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -1,6 +1,7 @@
 // components/FeaturesSection.tsx
 "use client";
 import { motion } from "framer-motion";
+import { GlassCard } from "./GlassCard";
 
 const sectionVariants = {
   hidden: { opacity: 0 },
@@ -41,26 +42,26 @@ export default function FeaturesSection() {
           </motion.p>
           
           <motion.div className="grid grid-cols-1 md:grid-cols-3 gap-8" variants={itemVariants}>
-            <div className="glass-card">
+            <GlassCard extraClasses="text-center">
               <h3 className="feature-heading">Fast & Verified</h3>
               <p className="feature-text">
                 Immediate and verified matching connects donors quickly with those in need.
               </p>
-            </div>
-            
-            <div className="glass-card">
+            </GlassCard>
+
+            <GlassCard extraClasses="text-center">
               <h3 className="feature-heading">Secure & Private</h3>
               <p className="feature-text">
                 Robust data encryption and discreet communication ensure your privacy.
               </p>
-            </div>
-            
-            <div className="glass-card">
+            </GlassCard>
+
+            <GlassCard extraClasses="text-center">
               <h3 className="feature-heading">Community Impact</h3>
               <p className="feature-text">
                 Join a growing network that transforms healthcare by saving lives every day.
               </p>
-            </div>
+            </GlassCard>
           </motion.div>
           
           {/* Stats Section */}

--- a/src/components/HeroCanvas.jsx
+++ b/src/components/HeroCanvas.jsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, useTexture } from "@react-three/drei";
+import { ParticleField } from "./ParticleField";
 
 export default function HeroCanvas() {
   return (
@@ -17,6 +18,7 @@ export default function HeroCanvas() {
           minPolarAngle={Math.PI / 2}
         />
         <BloodCellMesh />
+        <ParticleField count={1000} />
         <ambientLight intensity={0.5} />
         <directionalLight position={[10, 10, 10]} intensity={0.8} color="#ffffff" />
         <spotLight 


### PR DESCRIPTION
## Summary
- showcase glass card styling in `FeaturesSection`
- add particle field effect inside `HeroCanvas`
- expand about page with advanced stats
- create a new contact page using header, google map and twitter feed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68584135178c8329ba6829d3cb89a9bb