### PR TITLE
Fix MapComponent dynamic import

### DIFF
--- a/src/components/MapComponent.tsx
+++ b/src/components/MapComponent.tsx
@@ -243,3 +243,5 @@ export function MapComponent({
     </div>
   )
 }
+
+export default MapComponent


### PR DESCRIPTION
## Summary
- fix MapComponent import by adding a default export

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858463a56dc8329b4af59f68f82ccc0