### PR TITLE
Improve styling and search page layout

### DIFF
--- a/src/app/donate/page.js
+++ b/src/app/donate/page.js
@@ -64,8 +64,8 @@ export default function Donate() {
         <div className="container relative z-10 py-16">
           {/* Page Header */}
           <div className="text-center mb-16 fade-in">
-            <div className="inline-flex items-center justify-center w-20 h-20 bg-accent rounded-full shadow-xl mb-6">
-              <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-accent rounded-full shadow-xl mb-6">
+              <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
               </svg>
             </div>
@@ -95,8 +95,8 @@ export default function Donate() {
               {submitted && (
                 <div className="absolute inset-0 bg-white flex items-center justify-center z-50 scale-in">
                   <div className="text-center">
-                    <div className="w-24 h-24 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
-                      <svg className="w-12 h-12 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
+                      <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                       </svg>
                     </div>
@@ -248,8 +248,8 @@ export default function Donate() {
                 <div className="mt-8 pt-8 border-t border-gray-200">
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div className="text-center group">
-                      <div className="w-16 h-16 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
-                        <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
+                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
                         </svg>
                       </div>
@@ -258,8 +258,8 @@ export default function Donate() {
                     </div>
                     
                     <div className="text-center group">
-                      <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
-                        <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
+                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                                                     <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                         </svg>
                       </div>
@@ -268,8 +268,8 @@ export default function Donate() {
                     </div>
                     
                     <div className="text-center group">
-                      <div className="w-16 h-16 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
-                        <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md group-hover:shadow-lg transition-shadow">
+                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                         </svg>
                       </div>

--- a/src/app/emergency-request/page.tsx
+++ b/src/app/emergency-request/page.tsx
@@ -90,8 +90,8 @@ export default function EmergencyRequestPage(): JSX.Element {
         <div className="container relative z-10 py-16">
           {/* Page Header */}
           <div className="text-center mb-12 fade-in">
-            <div className="inline-flex items-center justify-center w-20 h-20 bg-accent rounded-full shadow-xl mb-6">
-              <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+            <div className="inline-flex items-center justify-center w-12 h-12 bg-accent rounded-full shadow-xl mb-6">
+              <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"/>
               </svg>
             </div>
@@ -125,8 +125,8 @@ export default function EmergencyRequestPage(): JSX.Element {
               {submitted && (
                 <div className="absolute inset-0 bg-white flex items-center justify-center z-50 scale-in">
                   <div className="text-center">
-                    <div className="w-24 h-24 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
-                      <svg className="w-12 h-12 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
+                      <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                       </svg>
                     </div>
@@ -514,8 +514,8 @@ export default function EmergencyRequestPage(): JSX.Element {
               <h3 className="text-2xl font-bold text-primary mb-6">Emergency Contact</h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="text-center">
-                  <div className="w-16 h-16 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
                     </svg>
                   </div>
@@ -525,8 +525,8 @@ export default function EmergencyRequestPage(): JSX.Element {
                 </div>
                 
                 <div className="text-center">
-                  <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.89 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                     </svg>
                   </div>
@@ -536,8 +536,8 @@ export default function EmergencyRequestPage(): JSX.Element {
                 </div>
                 
                 <div className="text-center">
-                  <div className="w-16 h-16 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                     </svg>
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -414,6 +414,24 @@ body {
   line-height: 1.7;
 }
 
+/* Call-to-action button in hero section */
+.hero-button {
+  background: var(--colour-accent);
+  color: var(--white);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  transition: background var(--transition-normal), transform var(--transition-normal);
+  display: inline-block;
+  box-shadow: var(--shadow-md);
+}
+
+.hero-button:hover {
+  background: var(--colour-accent-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
 .hero-image-container {
   width: 100%;
   position: relative;
@@ -856,6 +874,13 @@ body {
 .updates-text {
   color: var(--text-light);
   line-height: 1.6;
+}
+
+/* Small arrow icon in updates link */
+.updates-arrow {
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-left: 0.25rem;
 }
 
 /*-------------------------------------------
@@ -2607,6 +2632,12 @@ input:checked + .notification-slider:before {
   color: var(--colour-accent);
 }
 
+/* Reduce default icon size in forms */
+.form-group svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 /* Tooltip for help text */
 .help-tooltip {
   position: relative;
@@ -3810,6 +3841,34 @@ html.scroll-smooth {
 .global-loading-text {
   color: var(--colour-primary);
   font-weight: 500;
+}
+
+/*-------------------------------------------
+  Footer Styles
+-------------------------------------------*/
+.footer {
+  background: var(--colour-primary);
+  color: var(--white);
+  padding: var(--spacing-lg) var(--spacing-sm);
+  margin-top: var(--spacing-4xl);
+}
+
+.footer-link {
+  color: var(--white);
+  transition: color var(--transition-normal);
+}
+
+.footer-link:hover {
+  color: var(--colour-accent);
+}
+
+.footer-social-icon {
+  color: var(--white);
+  transition: color var(--transition-normal);
+}
+
+.footer-social-icon:hover {
+  color: var(--colour-accent);
 }
 
 /* Responsive typography scaling */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,9 +30,9 @@ export default function HomePage() {
 
       {/* Animated Gradient Overlay */}
       <motion.div
-        className="absolute inset-0 bg-gradient-to-br from-red-800 via-pink-700 to-yellow-500 opacity-70 animate-gradient"
+        className="absolute inset-0 bg-gradient-to-br from-red-800 via-pink-700 to-yellow-500 opacity-60 animate-gradient"
         initial={{ opacity: 0 }}
-        animate={{ opacity: 0.7 }}
+        animate={{ opacity: 0.6 }}
         transition={{ duration: 2 }}
       ></motion.div>
 

--- a/src/app/register/page.jsx
+++ b/src/app/register/page.jsx
@@ -117,8 +117,8 @@ function RegisterPageInner() {
               {/* Left Side - Hero Content */}
               <div className="order-2 lg:order-1 fade-in">
                 <div className="text-center lg:text-left">
-                  <div className="inline-flex items-center justify-center w-20 h-20 bg-accent rounded-full shadow-xl mb-6">
-                    <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="inline-flex items-center justify-center w-12 h-12 bg-accent rounded-full shadow-xl mb-6">
+                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
                     </svg>
                   </div>
@@ -134,8 +134,8 @@ function RegisterPageInner() {
                   {/* Benefits */}
                   <div className="space-y-4">
                     <div className="flex items-center text-left">
-                      <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mr-4">
-                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                      <div className="w-10 h-10 bg-primary rounded-full flex items-center justify-center mr-4">
+                        <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                         </svg>
                       </div>
@@ -145,8 +145,8 @@ function RegisterPageInner() {
                       </div>
                     </div>
                     <div className="flex items-center text-left">
-                      <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mr-4">
-                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                      <div className="w-10 h-10 bg-secondary rounded-full flex items-center justify-center mr-4">
+                        <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
                         </svg>
                       </div>
@@ -156,8 +156,8 @@ function RegisterPageInner() {
                       </div>
                     </div>
                     <div className="flex items-center text-left">
-                      <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mr-4">
-                        <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                      <div className="w-10 h-10 bg-accent rounded-full flex items-center justify-center mr-4">
+                        <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2z"/>
                         </svg>
                       </div>
@@ -178,8 +178,8 @@ function RegisterPageInner() {
                   {submitted && (
                     <div className="absolute inset-0 bg-white flex items-center justify-center z-50 scale-in">
                       <div className="text-center">
-                        <div className="w-24 h-24 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
-                          <svg className="w-12 h-12 text-white" fill="currentColor" viewBox="0 0 24 24">
+                        <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
+                          <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                           </svg>
                         </div>
@@ -774,7 +774,7 @@ function RegisterPageInner() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               <div className="bg-white rounded-lg p-6 shadow-lg">
                 <div className="flex items-center mb-4">
-                  <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center text-white font-bold mr-4">
+                  <div className="w-10 h-10 bg-primary rounded-full flex items-center justify-center text-white font-bold mr-4">
                     SM
                   </div>
                   <div>
@@ -793,7 +793,7 @@ function RegisterPageInner() {
               
               <div className="bg-white rounded-lg p-6 shadow-lg">
                 <div className="flex items-center mb-4">
-                  <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center text-white font-bold mr-4">
+                  <div className="w-10 h-10 bg-accent rounded-full flex items-center justify-center text-white font-bold mr-4">
                     DJ
                   </div>
                   <div>
@@ -812,7 +812,7 @@ function RegisterPageInner() {
               
               <div className="bg-white rounded-lg p-6 shadow-lg">
                 <div className="flex items-center mb-4">
-                  <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center text-white font-bold mr-4">
+                  <div className="w-10 h-10 bg-secondary rounded-full flex items-center justify-center text-white font-bold mr-4">
                     MR
                   </div>
                   <div>

--- a/src/app/search/page.jsx
+++ b/src/app/search/page.jsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState } from "react"
+import Footer from '@/components/Footer'
 
 export default function SearchPage() {
   const [bloodGroup, setBloodGroup] = useState("")
@@ -18,51 +19,56 @@ export default function SearchPage() {
   }
 
   return (
-    <div style={{ padding: "1rem" }}>
-      <h1>Search for Donors</h1>
-      <form onSubmit={handleSearch}>
-        <label>
-          Blood Group<br/>
-          <select
-            value={bloodGroup}
-            onChange={(e) => setBloodGroup(e.target.value)}
-            required
-          >
-            <option value="">Select Blood Group</option>
-            <option value="A+">A+</option>
-            <option value="A-">A-</option>
-            <option value="B+">B+</option>
-            <option value="B-">B-</option>
-            <option value="AB+">AB+</option>
-            <option value="AB-">AB-</option>
-            <option value="O+">O+</option>
-            <option value="O-">O-</option>
-          </select>
-        </label>
-        <br/><br/>
-        <label>
-          Location<br/>
-          <input
-            type="text"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            required
-          />
-        </label>
-        <br/><br/>
-        <button type="submit">Search</button>
-      </form>
-
-      <div style={{ marginTop: "2rem" }}>
-        {results.map((donor) => (
-          <div key={donor.id} style={{ marginBottom: "1rem" }}>
-            <p>
-              <strong>Name:</strong> {donor.name}<br/>
-              <strong>Blood Group:</strong> {donor.bloodGroup}
-            </p>
+    <div className="min-h-screen flex flex-col">
+      <section className="container mx-auto flex-1 py-16 space-y-8">
+        <h1 className="text-3xl font-bold text-primary text-center">Search for Donors</h1>
+        <form onSubmit={handleSearch} className="space-y-6 max-w-md mx-auto">
+          <div className="form-group">
+            <label className="form-label">Blood Group</label>
+            <select
+              value={bloodGroup}
+              onChange={(e) => setBloodGroup(e.target.value)}
+              required
+              className="form-input"
+            >
+              <option value="">Select Blood Group</option>
+              <option value="A+">A+</option>
+              <option value="A-">A-</option>
+              <option value="B+">B+</option>
+              <option value="B-">B-</option>
+              <option value="AB+">AB+</option>
+              <option value="AB-">AB-</option>
+              <option value="O+">O+</option>
+              <option value="O-">O-</option>
+            </select>
           </div>
-        ))}
-      </div>
+          <div className="form-group">
+            <label className="form-label">Location</label>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              required
+              className="form-input"
+              placeholder="Enter city or state"
+            />
+          </div>
+          <button type="submit" className="btn btn-primary btn-md w-full">Search</button>
+        </form>
+
+        <div className="space-y-4">
+          {results.map((donor) => (
+            <div key={donor.id} className="p-4 bg-white rounded-lg shadow">
+              <p className="text-sm text-dark">
+                <strong>Name:</strong> {donor.name}
+                <br />
+                <strong>Blood Group:</strong> {donor.bloodGroup}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <Footer />
     </div>
   )
 }

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -17,10 +17,7 @@ export default function HeroSection() {
             <p className="hero-description">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed diam nonumy eirot, utricien ulsum.
             </p>
-            <Link
-              href="/donate"
-              className="hero-button"
-            >
+            <Link href="/donate" className="hero-button">
               GET STARTED
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- tweak hero CTA to be a proper button
- adjust overlay on homepage
- make arrow icon small and style footer
- reduce default form icon size
- redesign search page to match global styling

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685873639b1c8329a0bea62a4ca1c26a