### PR TITLE
Fix oversized icons and button SVGs

### DIFF
--- a/src/app/emergency-request/page.tsx
+++ b/src/app/emergency-request/page.tsx
@@ -90,8 +90,8 @@ export default function EmergencyRequestPage(): JSX.Element {
         <div className="container relative z-10 py-16">
           {/* Page Header */}
           <div className="text-center mb-12 fade-in">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-accent rounded-full shadow-xl mb-6">
-              <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+            <div className="inline-flex items-center justify-center w-10 h-10 md:w-12 md:h-12 bg-accent rounded-full shadow-xl mb-6">
+              <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"/>
               </svg>
             </div>
@@ -514,8 +514,8 @@ export default function EmergencyRequestPage(): JSX.Element {
               <h3 className="text-2xl font-bold text-primary mb-6">Emergency Contact</h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="text-center">
-                  <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-10 h-10 md:w-12 md:h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
                     </svg>
                   </div>
@@ -525,8 +525,8 @@ export default function EmergencyRequestPage(): JSX.Element {
                 </div>
                 
                 <div className="text-center">
-                  <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-10 h-10 md:w-12 md:h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.89 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                     </svg>
                   </div>
@@ -536,8 +536,8 @@ export default function EmergencyRequestPage(): JSX.Element {
                 </div>
                 
                 <div className="text-center">
-                  <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
-                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-10 h-10 md:w-12 md:h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4 shadow-md">
+                    <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                     </svg>
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,6 +117,12 @@ body {
   text-align: center;
 }
 
+/* Ensure icons inside buttons scale with text */
+.btn svg {
+  width: 1em;
+  height: 1em;
+}
+
 .btn:focus {
   outline: 2px solid var(--colour-accent);
   outline-offset: 2px;
@@ -1050,7 +1056,13 @@ a:focus {
   .cta-buttons {
     gap: var(--spacing-sm);
   }
-  
+
+  .feature-icon,
+  .updates-icon {
+    width: 40px;
+    height: 40px;
+  }
+
   .navbar-container {
     padding: var(--spacing-sm);
   }

--- a/src/app/messaging/page.jsx
+++ b/src/app/messaging/page.jsx
@@ -142,7 +142,7 @@ export default function MessagingPage() {
             <div className="max-w-md mx-auto">
               <div className="glass-card fade-in">
                 <div className="bg-primary p-6 text-center">
-                  <div className="w-16 h-16 bg-white rounded-full flex items-center justify-center mx-auto mb-4">
+                  <div className="w-12 h-12 sm:w-16 sm:h-16 bg-white rounded-full flex items-center justify-center mx-auto mb-4">
                     <svg className="w-8 h-8 text-primary" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/>
                     </svg>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -88,10 +88,10 @@ export default function ProfilePage() {
               <div className="flex flex-col md:flex-row items-start md:items-center gap-6">
                 {/* Profile Avatar */}
                 <div className="relative">
-                  <div className="w-24 h-24 bg-accent rounded-full flex items-center justify-center text-white text-3xl font-bold shadow-xl">
+                  <div className="w-20 h-20 md:w-24 md:h-24 bg-accent rounded-full flex items-center justify-center text-white text-3xl font-bold shadow-xl">
                     {donorProfile.name.split(' ').map(n => n[0]).join('')}
                   </div>
-                  <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-primary rounded-full flex items-center justify-center text-white text-sm font-bold">
+                  <div className="absolute -bottom-2 -right-2 w-6 h-6 md:w-8 md:h-8 bg-primary rounded-full flex items-center justify-center text-white text-sm font-bold">
                     {donorProfile.bloodType}
                   </div>
                 </div>
@@ -286,8 +286,8 @@ export default function ProfilePage() {
                         <h3 className="text-xl font-bold text-primary mb-6">Your Impact</h3>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                           <div className="text-center">
-                            <div className="w-16 h-16 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
-                              <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                          <div className="w-12 h-12 md:w-16 md:h-16 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
+                              <svg className="w-6 h-6 md:w-8 md:h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
                               </svg>
                             </div>
@@ -295,8 +295,8 @@ export default function ProfilePage() {
                             <div className="text-sm text-light">Lives Potentially Saved</div>
                           </div>
                           <div className="text-center">
-                            <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
-                              <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                          <div className="w-12 h-12 md:w-16 md:h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
+                              <svg className="w-6 h-6 md:w-8 md:h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8 2h2v4h4v2h-4v4h-2v-4H7v-2h4V5z"/>
                               </svg>
                             </div>
@@ -304,8 +304,8 @@ export default function ProfilePage() {
                             <div className="text-sm text-light">Hospitals Helped</div>
                           </div>
                           <div className="text-center">
-                            <div className="w-16 h-16 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
-                              <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                          <div className="w-12 h-12 md:w-16 md:h-16 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
+                              <svg className="w-6 h-6 md:w-8 md:h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                               </svg>
                             </div>
@@ -327,8 +327,8 @@ export default function ProfilePage() {
                         {donorProfile.donationHistory.map((donation, index) => (
                           <div key={index} className="flex items-center justify-between p-4 bg-white rounded-lg border border-gray-100 hover:shadow-md transition-shadow">
                             <div className="flex items-center">
-                              <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mr-4">
-                                <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                              <div className="w-10 h-10 md:w-12 md:h-12 bg-accent rounded-full flex items-center justify-center mr-4">
+                                <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                                   <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
                                 </svg>
                               </div>
@@ -498,8 +498,8 @@ export default function ProfilePage() {
                         <h3 className="text-xl font-bold text-primary mb-6">Health Check History</h3>
                         <div className="space-y-4">
                           <div className="flex items-center p-4 bg-white rounded-lg border border-gray-100">
-                            <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mr-4">
-                              <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                            <div className="w-10 h-10 md:w-12 md:h-12 bg-primary rounded-full flex items-center justify-center mr-4">
+                              <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
                               </svg>
                             </div>
@@ -550,8 +550,8 @@ export default function ProfilePage() {
               </div>
               
               <div className="text-center mb-6">
-                <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-16 h-16 md:w-20 md:h-20 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-8 h-8 md:w-10 md:h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
                   </svg>
                 </div>

--- a/src/app/register-donor/page.tsx
+++ b/src/app/register-donor/page.tsx
@@ -580,8 +580,8 @@ export default function RegisterDonorPage() {
             {/* Information Cards */}
             <div className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6 slide-up" style={{ animationDelay: '0.2s' }}>
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                   </svg>
                 </div>
@@ -590,8 +590,8 @@ export default function RegisterDonorPage() {
               </div>
 
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
                   </svg>
                 </div>
@@ -600,8 +600,8 @@ export default function RegisterDonorPage() {
               </div>
 
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2z"/>
                   </svg>
                 </div>

--- a/src/app/register-recipient/page.tsx
+++ b/src/app/register-recipient/page.tsx
@@ -665,8 +665,8 @@ export default function RegisterRecipientPage() {
             {/* Emergency Information */}
             <div className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6 slide-up" style={{ animationDelay: '0.2s' }}>
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                   </svg>
                 </div>
@@ -675,8 +675,8 @@ export default function RegisterRecipientPage() {
               </div>
 
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                   </svg>
                 </div>
@@ -685,8 +685,8 @@ export default function RegisterRecipientPage() {
               </div>
 
               <div className="bg-white rounded-lg p-6 shadow-lg text-center">
-                <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 md:w-12 md:h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-5 h-5 md:w-6 md:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2z"/>
                   </svg>
                 </div>

--- a/src/components/MapComponent.tsx
+++ b/src/components/MapComponent.tsx
@@ -172,7 +172,7 @@ export default function MapComponent({
         ))}
       </MapContainer>
       <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center">
-        <MapPin className="h-12 w-12 text-muted-foreground mb-2" />
+        <MapPin className="h-10 w-10 sm:h-12 sm:w-12 text-muted-foreground mb-2" />
         <p className="text-muted-foreground mb-4">
           Find blood donors and hospitals across Nigeria
         </p>


### PR DESCRIPTION
## Summary
- scale down map icon for small screens
- reduce messaging intro icon size
- adjust profile icons and avatar sizes
- tweak emergency request icons
- make icons in registration pages responsive
- set button SVGs to scale with text and shrink feature icons on mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fac6284248329a21fd8f71a73746e