### PR TITLE
Fix placeholders for Nigerian audience

### DIFF
--- a/src/app/emergency-request/page.tsx
+++ b/src/app/emergency-request/page.tsx
@@ -341,7 +341,7 @@ export default function EmergencyRequestPage(): JSX.Element {
                         onChange={handleInputChange}
                         required
                         className="form-input"
-                        placeholder="New York"
+                        placeholder="Lagos"
                       />
                     </div>
                     <div className="form-group">
@@ -353,11 +353,11 @@ export default function EmergencyRequestPage(): JSX.Element {
                         onChange={handleInputChange}
                         required
                         className="form-input"
-                        placeholder="NY"
+                        placeholder="State"
                       />
                     </div>
                     <div className="form-group">
-                      <label className="form-label">Zip Code</label>
+                      <label className="form-label">Postal Code</label>
                       <input
                         type="text"
                         name="zipCode"
@@ -365,7 +365,7 @@ export default function EmergencyRequestPage(): JSX.Element {
                         onChange={handleInputChange}
                         required
                         className="form-input"
-                        placeholder="10001"
+                        placeholder="100001"
                       />
                     </div>
                   </div>
@@ -520,7 +520,7 @@ export default function EmergencyRequestPage(): JSX.Element {
                     </svg>
                   </div>
                   <h4 className="font-semibold text-primary mb-2">24/7 Hotline</h4>
-                  <p className="text-light mb-2">(555) 123-4567</p>
+                  <p className="text-light mb-2">0800 123 4567</p>
                   <p className="text-sm text-light">For immediate assistance</p>
                 </div>
                 
@@ -531,7 +531,7 @@ export default function EmergencyRequestPage(): JSX.Element {
                     </svg>
                   </div>
                   <h4 className="font-semibold text-primary mb-2">Emergency Email</h4>
-                  <p className="text-light mb-2">emergency@bloodbank.org</p>
+                  <p className="text-light mb-2">emergency@bloodlink.ng</p>
                   <p className="text-sm text-light">Monitored 24/7</p>
                 </div>
                 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,6 @@ export const metadata = {
   description: 'Nigeria\'s premier blood donation platform connecting donors with recipients across the country. Save lives, join our community of heroes.',
   keywords: 'blood donation, Nigeria, blood bank, emergency blood, donors, recipients, healthcare',
   authors: [{ name: 'BloodLink Team' }],
-  viewport: 'width=device-width, initial-scale=1',
   robots: 'index, follow',
   openGraph: {
     title: 'BloodLink - Connecting Blood Donors & Recipients',
@@ -22,6 +21,11 @@ export const metadata = {
     title: 'BloodLink - Connecting Blood Donors & Recipients',
     description: 'Nigeria\'s premier blood donation platform connecting donors with recipients across the country.',
   }
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/src/app/messaging/page.jsx
+++ b/src/app/messaging/page.jsx
@@ -22,7 +22,7 @@ export default function MessagingPage() {
     { id: 1, user: "System", message: "Welcome to BloodLink Emergency Chat", timestamp: Date.now(), type: "system" },
     { id: 2, user: "Dr. Smith", message: "We have an urgent O+ blood request at City Hospital", timestamp: Date.now() - 300000, type: "emergency" },
     { id: 3, user: "Sarah M.", message: "I'm O+ and available to donate. What's the timeline?", timestamp: Date.now() - 240000, type: "donor" },
-    { id: 4, user: "Dr. Smith", message: "Thank you Sarah! We need it within 2 hours. Please contact us at (555) 123-4567", timestamp: Date.now() - 180000, type: "medical" },
+    { id: 4, user: "Dr. Smith", message: "Thank you Sarah! We need it within 2 hours. Please contact us at 0800 123 4567", timestamp: Date.now() - 180000, type: "medical" },
   ]
 
   useEffect(() => {
@@ -442,13 +442,13 @@ export default function MessagingPage() {
               <h3 className="text-xl font-bold mb-2">Emergency Contact</h3>
               <p className="mb-4 opacity-90">For immediate medical emergencies, contact emergency services</p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <a href="tel:911" className="btn btn-ghost btn-md">
+                <a href="tel:112" className="btn btn-ghost btn-md">
                   <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
                   </svg>
-                  Call 911
+                  Call 112
                 </a>
-                <a href="tel:+15551234567" className="btn btn-ghost btn-md">
+                <a href="tel:+2348001234567" className="btn btn-ghost btn-md">
                   <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8 2h2v4h4v2h-4v4h-2v-4H7v-2h4V5z"/>
                   </svg>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -13,11 +13,11 @@ const donorProfile = {
   lastDonation: "2024-01-15",
   nextEligibleDate: "2024-03-15",
   joinedDate: "2022-10-01",
-  location: "New York, NY",
-  phone: "+1 (555) 123-4567",
+  location: "Lagos, NG",
+  phone: "+234 801 234 5678",
   emergencyContact: {
     name: "Jane Doe",
-    phone: "+1 (555) 987-6543"
+    phone: "+234 809 876 5432"
   },
   badges: [
     { id: 1, name: "First Time Hero", description: "Completed first donation", earned: true, date: "2022-10-15", icon: "🌟" },

--- a/src/app/register-recipient/page.tsx
+++ b/src/app/register-recipient/page.tsx
@@ -653,8 +653,8 @@ export default function RegisterRecipientPage() {
                         (234) 800-BLOOD
                       </a>{" "}
                       or{" "}
-                      <a href="mailto:help@bloodbank.org" className="text-accent hover:text-accent-hover font-semibold">
-                        help@bloodbank.org
+                      <a href="mailto:help@bloodlink.ng" className="text-accent hover:text-accent-hover font-semibold">
+                        help@bloodlink.ng
                       </a>
                     </p>
                   </div>

--- a/src/app/register/page.jsx
+++ b/src/app/register/page.jsx
@@ -364,14 +364,14 @@ function RegisterPageInner() {
                           </div>
 
                           <div className="form-group">
-                            <label className="form-label">Zip Code</label>
+                            <label className="form-label">Postal Code</label>
                             <input
                               type="text"
                               name="zipCode"
                               value={donorForm.zipCode}
                               onChange={handleDonorInputChange}
                               className="form-input"
-                              placeholder="Enter zip code"
+                              placeholder="Enter postal code"
                               required
                             />
                           </div>
@@ -587,14 +587,14 @@ function RegisterPageInner() {
                           </div>
 
                           <div className="form-group">
-                            <label className="form-label">Zip Code</label>
+                            <label className="form-label">Postal Code</label>
                             <input
                               type="text"
                               name="zipCode"
                               value={recipientForm.zipCode}
                               onChange={handleRecipientInputChange}
                               className="form-input"
-                              placeholder="Enter zip code"
+                              placeholder="Enter postal code"
                               required
                             />
                           </div>

--- a/src/components/EmergencyRequestPage.jsx
+++ b/src/components/EmergencyRequestPage.jsx
@@ -267,7 +267,7 @@ export default function EmergencyRequestPage() {
                   <FormItem>
                     <FormLabel>City</FormLabel>
                     <FormControl>
-                      <Input placeholder="New York" {...field} />
+                      <Input placeholder="Lagos" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -280,7 +280,7 @@ export default function EmergencyRequestPage() {
                   <FormItem>
                     <FormLabel>State</FormLabel>
                     <FormControl>
-                      <Input placeholder="NY" {...field} />
+                      <Input placeholder="State" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -291,9 +291,9 @@ export default function EmergencyRequestPage() {
                 name="zipCode"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Zip Code</FormLabel>
+                    <FormLabel>Postal Code</FormLabel>
                     <FormControl>
-                      <Input placeholder="10001" {...field} />
+                      <Input placeholder="100001" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
## Summary
- localize city and postal code placeholders
- update hotline phone numbers and emergency contact info
- replace sample data with Nigeria-specific details

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68601dd676f48329a55a832c8f086a87